### PR TITLE
fix: undefined reference to factorial

### DIFF
--- a/abc/src/bool/lucky/luckySimple.c
+++ b/abc/src/bool/lucky/luckySimple.c
@@ -103,7 +103,7 @@ void fillInFlipArray(permInfo* pi)
 	
 	
 }
-inline int factorial(int n)
+static inline int factorial(int n)
 {
 	return (n == 1 || n == 0) ? 1 : factorial(n - 1) * n;
 }


### PR DESCRIPTION
this fixes the following error after running make
```
`` Building binary: abc
src/bool/lucky/luckySimple.o: In function `factorial':
/home/tyler/yosys-abc/abc/src/bool/lucky/luckySimple.c:108: undefined reference to `factorial'
collect2: error: ld returned 1 exit status
Makefile:134: recipe for target 'abc' failed
make: *** [abc] Error 1
```